### PR TITLE
shippable: install_deps.sh:  Install pyelftools

### DIFF
--- a/shippable/install_deps.sh
+++ b/shippable/install_deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 echo "==================== Installing zephyr dependencies ==================="
-apt-get install git make gcc g++ python3-ply python3-yaml python-yaml doxygen device-tree-compiler qemu
+apt-get install git make gcc g++ python3-ply python3-yaml python-yaml doxygen device-tree-compiler qemu python3-pyelftools
 pip install awscli breathe==4.6.0 sphinx==1.5.5 sphinx_rtd_theme junit2html
 
 


### PR DESCRIPTION
This library is needed to execute the gen_offset_header.py and
gen_idt.py scripts.

Signed-off-by: Leandro Pereira <leandro.pereira@intel.com>