### PR TITLE
ci: add g++-multilib to the Shippable config.

### DIFF
--- a/shippable/install_deps.sh
+++ b/shippable/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 echo "==================== Installing zephyr dependencies ==================="
 apt-get install git make gcc g++ python3-ply python3-yaml doxygen device-tree-compiler qemu
-apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm libreadline-dev makeself p7zip-full cpio gperf
+apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib g++-multilib build-essential chrpath socat libsdl1.2-dev xterm libreadline-dev makeself p7zip-full cpio gperf
 apt-get install python3-pip
 apt-get install gcc-6-multilib gcovr valgrind ninja-build lcov
 


### PR DESCRIPTION
This is needed for building C++ samples on BOARD=native_posix.

Signed-off-by: Michael Hope <mlhx@google.com>