### PR TITLE
doc: update doc building tools

### DIFF
--- a/shippable/install_deps.sh
+++ b/shippable/install_deps.sh
@@ -7,7 +7,7 @@ apt-get install gcc-6-multilib gcovr valgrind ninja-build lcov
 
 # for net-tools
 apt-get install libglib2.0-dev libpcap-dev
-pip3 install awscli breathe==4.7.3 sphinx==1.6.5 docutils==0.14 sphinx_rtd_theme junit2html
+pip3 install awscli breathe==4.9.1 sphinx==1.7.5 docutils==0.14 sphinx_rtd_theme junit2html
 pip3 install pyelftools==0.24 pykwalify sh gitlint==0.9.0 pyserial
 
 CCACHE_VERSION="3.4.2"


### PR DESCRIPTION
breathe 4.9.1 and sphinx 1.7.5 play nice together now so update to these
latest versions  (a new "expected" warning does show up though, and is
handled by the known-issues filter update in #8375 (merged already)

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>