### PR TITLE
BabbleSim: Allow write to all

### DIFF
--- a/shippable/install_bsim.sh
+++ b/shippable/install_bsim.sh
@@ -8,4 +8,5 @@ curl https://storage.googleapis.com/git-repo-downloads/repo > ./repo  && chmod a
 ./repo sync
 make everything -j 8
 echo $BSIM_VERSION > ./version
+chmod ag+w . -R
 echo "=============== Successfully Installed BabbleSim ============"


### PR DESCRIPTION
Give write permissions to all in the BabbleSim folder
so we can fetch new components or update them without the
need to modify the docker image each time.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>

CC  @nashif 