### PR TITLE
new python packages, version updates

### DIFF
--- a/shippable/install_deps.sh
+++ b/shippable/install_deps.sh
@@ -7,8 +7,9 @@ apt-get install gcc-6-multilib gcovr valgrind ninja-build lcov
 
 # for net-tools
 apt-get install libglib2.0-dev libpcap-dev
-pip3 install awscli breathe==4.9.1 sphinx==1.7.5 docutils==0.14 sphinx_rtd_theme junit2html
-pip3 install pyelftools==0.24 pykwalify sh gitlint==0.9.0 pyserial
+wget -q https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt
+pip3 install -r requirements.txt
+pip3 install awscli west PyGithub junitparser
 
 CCACHE_VERSION="3.4.2"
 wget https://www.samba.org/ftp/ccache/ccache-${CCACHE_VERSION}.tar.bz2
@@ -22,8 +23,8 @@ cd ..
 rm -rf ccache-${CCACHE_VERSION} ccache-${CCACHE_VERSION}.tar.bz2
 
 
-CMAKE_VERSION=3.9.1
-wget -q https://cmake.org/files/v3.9/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+CMAKE_VERSION=3.8.2
+wget -q https://cmake.org/files/v3.8/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
 tar xf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
 cp -a cmake-${CMAKE_VERSION}-Linux-x86_64/bin/* /usr/local/bin/
 cp -a cmake-${CMAKE_VERSION}-Linux-x86_64/share/* /usr/local/share/

--- a/shippable/install_esp32.sh
+++ b/shippable/install_esp32.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-
-
 mkdir -p /opt/toolchain/esp32
 cd /opt/toolchain/esp32
 wget https://dl.espressif.com/dl/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar.gz

--- a/shippable/install_vendor_toolchains.sh
+++ b/shippable/install_vendor_toolchains.sh
@@ -6,15 +6,3 @@ rm -f gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
 mkdir /opt/toolchain
 mv gcc-arm-none-eabi-7-2018-q2-update /opt/toolchain/arm-none-eabi
 
-wget -q http://registrationcenter-download.intel.com/akdlm/irc_nas/9572/issm-toolchain-linux-2017-02-07.tar.gz
-tar xf issm-toolchain-linux-2017-02-07.tar.gz
-rm issm-toolchain-linux-2017-02-07.tar.gz
-mv issm-toolchain-linux-2017-02-07 /opt/toolchain/issm
-
-#wget -q https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/releases/download/arc-2016.09-release/arc_gnu_2016.09_prebuilt_elf32_le_linux_install.tar.gz
-#tar xf arc_gnu_2016.09_prebuilt_elf32_le_linux_install.tar.gz
-#rm arc_gnu_2016.09_prebuilt_elf32_le_linux_install.tar.gz
-#mv arc_gnu_2016.09_prebuilt_elf32_le_linux_install /opt/toolchain/arc-elf32
-
-
-


### PR DESCRIPTION
- Install cmake 3.8.2 to match required version in Zephyr
- Do not install ISSM toolchain
- Install west, pygithub and junitparser
- Use requirements.txt file from tree to keep things synced

Signed-off-by: Anas Nashif <anas.nashif@intel.com>