### PR TITLE
Add Renode to the Dockerfile

### DIFF
--- a/shippable/Dockerfile
+++ b/shippable/Dockerfile
@@ -9,6 +9,7 @@ RUN /shippable/install_sdk_ng.sh
 RUN /shippable/install_vendor_toolchains.sh
 RUN /shippable/install_esp32.sh
 RUN /shippable/install_bsim.sh
+RUN /shippable/install_renode.sh
 RUN /shippable/install_source.sh
 
 RUN useradd -m -G plugdev buildslave \

--- a/shippable/install_renode.sh
+++ b/shippable/install_renode.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+VERSION=1.6.2
+
+apt-get install --no-install-recommends -y gnupg ca-certificates apt-transport-https
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+echo "deb https://download.mono-project.com/repo/ubuntu stable-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+sudo apt update
+apt-get install --no-install-recommends -y gtk-sharp2 libgtk2.0-0 mono-complete
+
+wget -O renode.deb https://github.com/renode/renode/releases/download/v${VERSION}/renode_${VERSION}_amd64.deb
+apt install -y ./renode.deb
+rm renode.deb


### PR DESCRIPTION
This adds Renode 1.6.2 as a dependency, to be used with tests available
via sanitycheck.

I did not manage to run sanitycheck on this image with the current Zephyr, as the DTC version seems to be outdated - but I'm not sure how does the workflow used by shippable look like, so I'm open to comments.

EDIT: I added a proper DTC manually and everything seems to be working fine.