### PR TITLE
Add MCUBoot pip dependencies

### DIFF
--- a/shippable/Dockerfile
+++ b/shippable/Dockerfile
@@ -11,6 +11,7 @@ RUN /shippable/install_esp32.sh
 RUN /shippable/install_bsim.sh
 RUN /shippable/install_renode.sh
 RUN /shippable/install_source.sh
+RUN /shippable/install_mcuboot.sh
 
 RUN useradd -m -G plugdev buildslave \
  && echo 'buildslave ALL = NOPASSWD: ALL' > /etc/sudoers.d/buildslave \

--- a/shippable/install_mcuboot.sh
+++ b/shippable/install_mcuboot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+wget -O mcuboot_requirements.txt https://raw.githubusercontent.com/JuulLabs-OSS/mcuboot/master/scripts/requirements.txt
+pip3 install -r mcuboot_requirements.txt


### PR DESCRIPTION
It has been a common request for CI to be able to integration test
MCUBoot, and in
https://github.com/zephyrproject-rtos/zephyr/pull/13672 this becomes
possible, but it requires that Zephyr's CI has MCUBoot's dependencies
installed.

To resolve this we add MCUBoot's dependencies to the CI Dockerfile,
currently, this consists only of pip packages, so we download
MCUboot's requirements.txt file and have pip install them.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>