### PR TITLE
Add SDL2 dependecy

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -30,6 +30,7 @@ apt-get install -y \
 	chrpath \
 	socat \
 	libsdl1.2-dev \
+	libsdl2-dev \
 	xterm \
 	libreadline-dev \
 	makeself \


### PR DESCRIPTION
Added dependency towards libsdl2-dev, this will allow to build samples/tests which use the SDL display driver.

Note that this will only work for native_posix_64 as the 32-bit can not be installed in the CI image due to dependency conflicts.