### PR TITLE
Bump renode to v1.8.2.

### DIFF
--- a/shippable/install_renode.sh
+++ b/shippable/install_renode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.6.2
+VERSION=1.8.2
 
 apt-get install --no-install-recommends -y gnupg ca-certificates apt-transport-https
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF


### PR DESCRIPTION
This commit changes install_renode.sh to pull in the renode version
1.8.2, instead of 1.6.2.

Old renode releases (< 1.8.1) are affected by the issue
renode/renode#43 when running with the latest stable Mono runtime
(6.4.0 at the time of writing).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>