### PR TITLE
Add support to build/run C++ tests on native_posix

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -59,7 +59,7 @@ sudo pip install awsebcli=="$AWSEBCLI_VERSION"
 echo "======================= Installing gcc 6 ======================"
 add-apt-repository ppa:ubuntu-toolchain-r/test
 apt-get update
-apt-get install gcc-6 g++-6
+apt-get install gcc-6 g++-6 gcc-6-multilib g++-6-multilib
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 50 --slave /usr/bin/g++ g++ /usr/bin/g++-6
 update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-6 50
 gcc --version
@@ -113,7 +113,6 @@ apt-get install -y \
 	cpio \
 	gperf \
 	python3-pip \
-	gcc-6-multilib \
 	gcovr \
 	valgrind \
 	ninja-build \


### PR DESCRIPTION
Add support to build/run C++ tests on native_posix by adding g++ multilib support and bumping gcc/g++ to latest stable version (9)  to add C++17 support.

Fixes: #19