### PR TITLE
Add dependencies for the EDTT (BLE conformance test suite)

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -34,7 +34,7 @@ python-dev=2.7*
 
 pip install -q virtualenv==16.5.0
 pip install -q pyOpenSSL==19.0.0
-
+pip install -q statistics numpy==1.16.5 enum34 #Needed by EDTT
 
 export JQ_VERSION=1.5*
 echo "================= Adding JQ $JQ_VERSION ========================="

--- a/shippable/install_bsim.sh
+++ b/shippable/install_bsim.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 echo "==================== Installing BabbleSim ==================="
-export BSIM_VERSION=v1.0.2
+export BSIM_VERSION=v1.0.3
 mkdir -p /opt/bsim
 cd /opt/bsim
 curl https://storage.googleapis.com/git-repo-downloads/repo > ./repo  && chmod a+x ./repo 


### PR DESCRIPTION
Fetch the latest version of BabbleSim, apart from a few
very minor updates, this manifest pulls also the
edtt_bridge which is necessary to connect the EDTT
to a set of simulated devices.
+
install.sh: Install extra python dependencies needed by EDTT