### PR TITLE
Dockerfile: move base image to Ubuntu 18.04

### DIFF
--- a/shippable/Dockerfile
+++ b/shippable/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ADD . /shippable
 

--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -28,8 +28,8 @@ smbclient
 
 echo "================= Installing Python packages =================="
 apt-get install -q -y \
-python-pip=8.1* \
-python-software-properties=0.96* \
+python-pip=9.0* \
+software-properties-common=0.96* \
 python-dev=2.7*
 
 pip install -q virtualenv==16.5.0


### PR DESCRIPTION
This provides Python 3.6, which will be the minimum supported version
when https://github.com/zephyrproject-rtos/zephyr/pull/21212 is
merged.