### PR TITLE
Change ownership of /opt/modules & /opt/tools to buildslave

### DIFF
--- a/shippable/Dockerfile
+++ b/shippable/Dockerfile
@@ -3,15 +3,16 @@ FROM ubuntu:18.04
 ADD . /shippable
 
 RUN /shippable/install.sh && rm -rf /tmp && mkdir /tmp && chmod 1777 /tmp
+
+RUN useradd -m -G plugdev buildslave \
+ && echo 'buildslave ALL = NOPASSWD: ALL' > /etc/sudoers.d/buildslave \
+ && chmod 0440 /etc/sudoers.d/buildslave
+
 RUN /shippable/install_sdk.sh
 RUN /shippable/install_vendor_toolchains.sh
 RUN /shippable/install_bsim.sh
 RUN /shippable/install_renode.sh
 RUN /shippable/install_source.sh
-
-RUN useradd -m -G plugdev buildslave \
- && echo 'buildslave ALL = NOPASSWD: ALL' > /etc/sudoers.d/buildslave \
- && chmod 0440 /etc/sudoers.d/buildslave
 
 # Set the locale
 RUN locale-gen en_US.UTF-8

--- a/shippable/install_source.sh
+++ b/shippable/install_source.sh
@@ -40,3 +40,5 @@ rm west.yml
 cd ..
 rmdir /opt/z-modules
 rm -fr /opt/.west
+chown -R buildslave.buildslave /opt/modules/
+chown -R buildslave.buildslave /opt/tools/


### PR DESCRIPTION
* Move creating buildslave user before we setup modules

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>