### PR TITLE
install.sh: Add GNU parallel

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -120,6 +120,7 @@ apt-get install -y \
 	xterm \
 	libreadline-dev \
 	makeself \
+	parallel \
 	p7zip-full \
 	cpio \
 	gperf \


### PR DESCRIPTION
If GNU parallel is present the EDTT tests will run around 1 min
faster in CI.

Signed-off-by: Alberto Escolar Piedras <alpi@oticon.com>