### PR TITLE
shippable/install.sh: use Marti's zephyr requirements

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -132,7 +132,7 @@ apt-get install -y \
 	libpcap-dev \
 	locales
 
-pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt
+pip3 install -r https://raw.githubusercontent.com/mbolivar/zephyr/west-0.7.0-docs/scripts/requirements.txt
 pip3 install awscli PyGithub junitparser pylint
 
 # EDTT requirements


### PR DESCRIPTION
I'm not sure what the right thing to do is, but I want to test this tree with west 0.7 documentation:
https://github.com/mbolivar/zephyr/tree/west-0.7.0-docs

That requires west 0.7.0rc1 or later installed in the shippable container used for Zephyr CI.

Any advice @nashif @galak ?