### PR TITLE
cmake: update to cmake: 3.15.7

### DIFF
--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -145,3 +145,5 @@ pip3 install -q statistics numpy
 
 pip3 install -r https://raw.githubusercontent.com/JuulLabs-OSS/mcuboot/master/scripts/requirements.txt
 
+# imgtool, needed for MCUboot to sign images (i.e. for TF-M S/NS builds)
+pip3 install -q imgtool

--- a/shippable/install.sh
+++ b/shippable/install.sh
@@ -143,7 +143,7 @@ pip3 install -q statistics numpy
 
 # mcuboot requirements
 
-pip3 install -r https://raw.githubusercontent.com/JuulLabs-OSS/mcuboot/master/scripts/requirements.txt
+pip3 install -r https://raw.githubusercontent.com/mcu-tools/mcuboot/master/scripts/requirements.txt
 
 # imgtool, needed for MCUboot to sign images (i.e. for TF-M S/NS builds)
 pip3 install -q imgtool

--- a/shippable/install_source.sh
+++ b/shippable/install_source.sh
@@ -11,7 +11,7 @@ cd ..
 rm -rf ccache-${CCACHE_VERSION} ccache-${CCACHE_VERSION}.tar.bz2
 
 
-CMAKE_VERSION=3.13.1
+CMAKE_VERSION=3.15.7
 wget -q https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
 tar xf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
 cp -a cmake-${CMAKE_VERSION}-Linux-x86_64/bin/* /usr/local/bin/


### PR DESCRIPTION
Move cmake version to 3.15.7.
This is required for building Zephyr with TF-M support.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>