### PR TITLE
sdk: drop 0.11.4 SDK install

### DIFF
--- a/shippable/install_sdk.sh
+++ b/shippable/install_sdk.sh
@@ -1,12 +1,5 @@
 #!/bin/sh -e
 
-VERSION=0.11.4
-wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${VERSION}/zephyr-sdk-${VERSION}-setup.run
-chmod +x zephyr-sdk-${VERSION}-setup.run
-
-./zephyr-sdk-${VERSION}-setup.run --quiet -- -d /opt/sdk/zephyr-sdk-${VERSION}
-rm zephyr-sdk-${VERSION}-setup.run
-
 VERSION=0.12.1
 wget -q https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${VERSION}/zephyr-sdk-${VERSION}-x86_64-linux-setup.run
 chmod +x zephyr-sdk-${VERSION}-x86_64-linux-setup.run


### PR DESCRIPTION
Now that Zephyr is using SDK 0.12.x we can drop installing SDK 0.11.4
into the docker image.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>