### PR TITLE
fix renode 1.11.0 install

### DIFF
--- a/shippable/install_renode.sh
+++ b/shippable/install_renode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=1.11
+VERSION=1.11.0
 
 apt-get install --no-install-recommends -y gnupg ca-certificates apt-transport-https
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF


### PR DESCRIPTION
Had typo in version number so renode wasn't getting installed in
docker image

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>