### PR TITLE
add  libpython3.8-dev to support gdb

### DIFF
--- a/Dockerfile.user
+++ b/Dockerfile.user
@@ -7,6 +7,7 @@ RUN dpkg --add-architecture i386 && \
         apt-get install --no-install-recommends -y \
 	openbox \
 	python-xdg \
+	libpython3.8-dev \
 	x11vnc \
 	xvfb \
 	xterm \


### PR DESCRIPTION
GDB python extensions requires this python version.